### PR TITLE
Cambios propuestos

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ Filtros soportados:
 
 - `brand` — coincidencia exacta del nombre de marca.
 - `reference` — coincidencia exacta de `supplier_reference`.
-- `per_page` — tamaño de página (paginador estándar de Laravel).
+- `per_page` — tamaño de página (entero entre 1 y 50). Valores fuera de rango devuelven `422`.
+- `page` — número de página (entero ≥ 1).
+
+```bash
+curl -H "Accept: application/json" "http://127.0.0.1:8000/api/products?per_page=20&page=2"
+```
 
 ---
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\IndexProductRequest;
 use App\Http\Resources\ProductResource;
 use App\Models\Product;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 final class ProductController extends Controller
 {
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(IndexProductRequest $request): AnonymousResourceCollection
     {
         return ProductResource::collection(
             Product::query()

--- a/app/Http/Requests/IndexProductRequest.php
+++ b/app/Http/Requests/IndexProductRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class IndexProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'brand' => ['sometimes', 'string'],
+            'reference' => ['sometimes', 'string'],
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:50'],
+        ];
+    }
+}

--- a/app/Importing/ImportService.php
+++ b/app/Importing/ImportService.php
@@ -43,7 +43,7 @@ final class ImportService
 
     private function persist(Supplier $supplier, ImportedProductDTO $dto, ImportSummary $summary): void
     {
-        $brand = Brand::firstOrCreate(['name' => $dto->brand]);
+        $brand = Brand::updateOrCreate(['name' => $dto->brand], []);
 
         $existing = Product::where('supplier_id', $supplier->id)
             ->where('supplier_reference', $dto->supplierReference)

--- a/database/migrations/2026_05_05_005933_add_unique_index_to_brands_name.php
+++ b/database/migrations/2026_05_05_005933_add_unique_index_to_brands_name.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('brands', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('brands', function (Blueprint $table) {
+            $table->dropUnique(['name']);
+        });
+    }
+};

--- a/tests/Feature/ProductsIndexTest.php
+++ b/tests/Feature/ProductsIndexTest.php
@@ -50,6 +50,14 @@ final class ProductsIndexTest extends TestCase
         $response->assertJsonPath('meta.total', 7);
     }
 
+    public function test_rejects_per_page_above_max(): void
+    {
+        $response = $this->getJson('/api/products?per_page=9999999');
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['per_page']);
+    }
+
     public function test_response_includes_price_tiers_ordered_by_min_quantity(): void
     {
         $product = Product::factory()->create();


### PR DESCRIPTION
- per_page (prods) ahora está capeado a (1–50) y aclara que valores fuera de rango devuelven 422.
- Se evita race condition con updateOrCreate + migracion para que brands.name sea único.